### PR TITLE
feat: add github copilot locale setting

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -51,6 +51,7 @@
   "files.eol": "\n",
   "files.insertFinalNewline": true, // ファイル末尾に改行追加
   "git.autofetch": true,
+  "github.copilot.chat.localeOverride": "ja", // GitHub Copilotの言語設定
   "github.copilot.enable": { // GitHub Copilotの設定
     "*": true,
     "yaml": false,


### PR DESCRIPTION
## 概要

GitHub Copilot Chatで日本語で返すように設定を追加

## 詳細

- 正確には設定というかデフォルトのlocale？VS Codeの設定？を上書きするらしい。
- ドキュメントはみつからなかったので設定のキャプチャをメモしておく
<img width="575" alt="image" src="https://github.com/yamap55/dotfiles/assets/1785817/0b5e7caa-bf6f-4bde-8e6a-571aaa727338">

- Extension
  - https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat
