### PR TITLE
fix: adjust editor.findMatchHighlightBackground to use transparent color

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -64,7 +64,7 @@
     "[GitHub Dark]": {
       "editor.findMatchBorder": "#FDFF0C",
       "editor.findMatchBackground": "#ff0000",
-      "editor.findMatchHighlightBackground": "#ff0000"
+      "editor.findMatchHighlightBackground": "#ff000080"
     }
   },
   "workbench.colorTheme": "GitHub Dark", // 拡張機能が必要: GitHub.github-vscode-theme


### PR DESCRIPTION
![image](https://github.com/yamap55/dotfiles/assets/1785817/195c0225-ce85-4adb-afce-bbd0e0b6c710)

ChatGPT
https://chatgpt.com/share/a009f547-097b-4f0d-a2b4-0fc78b2078af