### PR TITLE
chore: remove "mosapride.zenkaku" setting

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -18,7 +18,6 @@
     "bierner.markdown-preview-github-styles",
     "eamodio.gitlens",
     "GitHub.github-vscode-theme",
-    "mosapride.zenkaku",
     "MS-CEINTL.vscode-language-pack-ja",
     "streetsidesoftware.code-spell-checker",
     "usernamehw.errorlens",


### PR DESCRIPTION
## 参考
- https://github.com/mosapride/vscode-zenkaku?tab=readme-ov-file#%E8%A3%9C%E8%B6%B3
- https://code.visualstudio.com/updates/v1_64#_unicode-highlighting-improvements