### PR TITLE
chore(claude): 会話ログの保持期間を無期限に延長

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "cleanupPeriodDays": 9999,
   "statusLine": {
     "type": "command",
     "command": "bash /home/yamap/.claude/statusline-command.sh"


### PR DESCRIPTION
## Summary

- `~/.claude/settings.json` に `cleanupPeriodDays: 9999` を追加

## Motivation

デフォルトの30日では過去の会話ログが削除されてしまう。
後から会話履歴を参照できるよう、保持期間を事実上無期限に変更する。