### PR TITLE
feat(claude): デフォルトモデルをopusに設定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "opus",
   "cleanupPeriodDays": 9999,
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
## Summary
- Claude Code のプロジェクト設定にデフォルトモデルとして `opus` を追加
- 毎回手動でモデルを切り替える手間を省く

## Test plan
- [x] `claude` 起動時にデフォルトで opus モデルが選択されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)