### PR TITLE
feat(claude): tui設定をfullscreenに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,5 @@
 {
-  "model": "opus",
-  "language": "japanese",
   "cleanupPeriodDays": 9999,
-  "statusLine": {
-    "type": "command",
-    "command": "bash /home/yamap/.claude/statusline-command.sh"
-  },
   "permissions": {
     "allow": [
       "Bash(npm run *)",
@@ -65,5 +59,12 @@
       "Read(.env)",
       "Read(.env.*)"
     ]
-  }
+  },
+  "model": "opus",
+  "statusLine": {
+    "type": "command",
+    "command": "bash /home/yamap/.claude/statusline-command.sh"
+  },
+  "language": "japanese",
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に `tui: "fullscreen"` を追加し、Claude Codeのfullscreenレンダリング（alternate screen buffer）を有効化

## Motivation
fullscreenレンダリングを試用して以下のメリットを確認したため、ローカル環境（Windows Terminal → WSL → zellij → claude）でも常用したい:
- ツール出力ストリーミング中のチラつき除去
- 長会話でもメモリ使用量が平坦
- 長文コピペ時に物理折り返しの改行が混入せず論理行で保持される（コードや長コマンドのコピペで意味が崩れない）

なお差分のキー順入れ替えは `/tui` コマンドの自動書き込み時の再シリアライズによるもので、設定値そのものの意味的変更はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)