### PR TITLE
feat(claude): GitHub Issue・PRにセッション復帰コマンドの記載ルールを追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,7 +43,12 @@
 # GitHub Issue・PR
 - 以下を行う際は、本文末尾にセッション復帰コマンドを記載する（後で投稿内容と作業セッションを紐づけて復帰するため）
   - Issue の作成 / Issue へのコメント投稿 / PR の作成
-  - 書式: `🔁 Resume session: \`claude -r <CLAUDE_CODE_SESSION_ID>\``
+  - 書式（下記をそのまま記載。バッククォートはエスケープしない）:
+
+    ```
+    🔁 Resume session: `claude -r <CLAUDE_CODE_SESSION_ID>`
+    ```
+
   - ID は `printenv CLAUDE_CODE_SESSION_ID` の値に置換する
 
 # コマンド出力

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,8 +40,9 @@
 - コミットメッセージは詳細かつ包括的に書く（何を・なぜ変更したかが伝わるように）
 - git の歴史改変は絶対に行わない（rebase, push --force, reset --hard, commit --amend 等）
 
-# GitHub Issue
-- Issue にコメントを投稿する際は、本文末尾にセッション復帰コマンドを記載する（後でコメントと作業セッションを紐づけて復帰するため）
+# GitHub Issue・PR
+- 以下を行う際は、本文末尾にセッション復帰コマンドを記載する（後で投稿内容と作業セッションを紐づけて復帰するため）
+  - Issue の作成 / Issue へのコメント投稿 / PR の作成
   - 書式: `🔁 Resume session: \`claude -r <CLAUDE_CODE_SESSION_ID>\``
   - ID は `printenv CLAUDE_CODE_SESSION_ID` の値に置換する
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,5 +40,10 @@
 - コミットメッセージは詳細かつ包括的に書く（何を・なぜ変更したかが伝わるように）
 - git の歴史改変は絶対に行わない（rebase, push --force, reset --hard, commit --amend 等）
 
+# GitHub Issue
+- Issue にコメントを投稿する際は、本文末尾にセッション復帰コマンドを記載する（後でコメントと作業セッションを紐づけて復帰するため）
+  - 書式: `🔁 Resume session: \`claude -r <CLAUDE_CODE_SESSION_ID>\``
+  - ID は `printenv CLAUDE_CODE_SESSION_ID` の値に置換する
+
 # コマンド出力
 - 長いコマンドを提示する際は、バックスラッシュ `\` で明示的に行継続する

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,7 @@
       "Bash(which *)",
       "Bash(echo *)",
       "Bash(cat *)",
+      "Bash(printenv CLAUDE_CODE_SESSION_ID)",
       "Bash(gh pr view *)",
       "Bash(gh pr list *)",
       "Bash(gh pr diff *)",


### PR DESCRIPTION
## 概要
`.claude/CLAUDE.md` に「GitHub Issue・PR」セクションを新設し、Issue・PRの作成やIssueコメント投稿時に、本文末尾へセッション復帰コマンドを記載するルールを定義しました。あわせて、セッションID取得に必要な許可設定を `.claude/settings.json` に追加しています。

## 変更内容
### `.claude/CLAUDE.md`
- 以下のアクション時に本文末尾へセッション復帰コマンドを記載するルールを追加
  - Issue の作成 / Issue へのコメント投稿 / PR の作成
- 書式: `🔁 Resume session: \`claude -r <CLAUDE_CODE_SESSION_ID>\``
- ID は `printenv CLAUDE_CODE_SESSION_ID` の値に置換する旨を明記

### `.claude/settings.json`
- `printenv CLAUDE_CODE_SESSION_ID` を `permissions.allow` に完全一致で追加
  - 対象変数のみ許可し、その他の `printenv` 実行には引き続き確認が入る

## なぜ
後から投稿内容（Issue・コメント・PR）と実際の作業セッションを紐づけ、`claude -r` で文脈ごと復帰できるようにするため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔁 Resume session: `claude -r 2e059e38-e987-44fb-8608-ed78d9058d3b`