### PR TITLE
chore(claude): permissions.defaultMode を auto に設定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "cleanupPeriodDays": 9999,
   "permissions": {
+    "defaultMode": "auto",
     "allow": [
       "Bash(npm run *)",
       "Bash(npm install *)",


### PR DESCRIPTION
## 概要

Claude Code の権限モードの既定値（`permissions.defaultMode`）を `auto` に設定する。

## 変更内容

- `.claude/settings.json` の `permissions` に `"defaultMode": "auto"` を追加

## 背景・目的

auto モードでは安全と判断される操作が自動的に許可される一方、破壊的・不可逆な操作や設定の自己改変などはこれまで通り確認・拒否される。日常的な操作のたびに許可プロンプトへ応答する手間を減らすことが目的。

## 参考

- https://code.claude.com/docs/en/permission-modes#available-modes

<img width="381" height="348" alt="image" src="https://github.com/user-attachments/assets/4a4bfd1e-89d8-418a-803b-ab31eb66d403" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔁 Resume session: `claude -r 995bfa72-63c8-4696-b8d3-76db00f11ad4`