### PR TITLE
chore(claude): auto モードのガードレール強化と設定項目の追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "cleanupPeriodDays": 9999,
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
       "Bash(npm run *)",
       "Bash(npm install *)",
@@ -49,24 +48,43 @@
     ],
     "deny": [
       "Bash(git push --force*)",
+      "Bash(git push -f*)",
       "Bash(git reset --hard*)",
       "Bash(git rebase*)",
       "Bash(git commit --amend*)",
       "Bash(rm -rf *)",
+      "Bash(rm -fr *)",
+      "Bash(rm -r -f *)",
+      "Bash(rm -f -r *)",
+      "Bash(rm --recursive *)",
+      "Bash(rm --force *)",
       "Bash(cat .env*)",
       "Bash(git restore *)",
       "Bash(git clean *)",
       "Edit(.env)",
       "Edit(.env.*)",
       "Read(.env)",
-      "Read(.env.*)"
+      "Read(.env.*)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/credentials)",
+      "Read(~/.gnupg/**)"
+    ],
+    "defaultMode": "auto"
+  },
+  "autoMode": {
+    "hard_deny": [
+      "$defaults",
+      "Never rewrite git history in any form: no git rebase, git push --force / -f / --force-with-lease, git reset --hard, or git commit --amend",
+      "Never read, write, or commit .env files or any file containing secrets, API keys, or credentials",
+      "Never delete directories recursively with force (rm -rf and any equivalent spelling)"
     ]
   },
+  "effortLevel": "high",
   "model": "opus",
   "statusLine": {
     "type": "command",
     "command": "bash /home/yamap/.claude/statusline-command.sh"
   },
   "language": "japanese",
-  "tui": "fullscreen"
+  "tui": "default"
 }


### PR DESCRIPTION
## 概要

`permissions.defaultMode: auto` で動作させる前提で、危険な操作が自動承認されないよう deny ルールと `autoMode.hard_deny` を整備した。

## 変更内容

### deny の拡充
- 破壊的コマンドの別表記を追加
  - `git push -f`（`--force` 以外の短縮形）
  - `rm` の再帰・強制削除の各種表記（`-fr` / `-r -f` / `-f -r` / `--recursive` / `--force`）
- 認証情報の読み取り禁止を追加
  - `~/.ssh/**`、`~/.aws/credentials`、`~/.gnupg/**`

### autoMode.hard_deny の新設
パターンマッチだけでは漏れる操作を自然言語ルールとして明示。

- git 履歴改変の全面禁止
- `.env` / シークレットを含むファイルの読み書き・コミット禁止
- 再帰的強制削除の禁止

### その他
- `effortLevel` を `high` に設定
- `tui` を `fullscreen` から `default` に変更

## 補足

`defaultMode` は `permissions` 内の記述位置のみ移動しており、値は `auto` のまま。

🔁 Resume session: `claude -r aefe1a8c-d2ec-4033-9f47-2b3f09391dcc`